### PR TITLE
Ignore Web Site projects

### DIFF
--- a/DontCopyAlways/SolutionProjects.cs
+++ b/DontCopyAlways/SolutionProjects.cs
@@ -32,7 +32,8 @@ namespace DontCopyAlways
 
             while (item.MoveNext())
             {
-                if (!(item.Current is Project project))
+                // skip if Current item is not a project or if the project Kind is a Web Site project
+                if (!(item.Current is Project project) || project.Kind == "{E24C65DC-7377-472b-9ABA-BC803B73C61A}")
                 {
                     continue;
                 }


### PR DESCRIPTION
Encountered a bug with a solution that has a Web Site project. I added a check that the project Kind is not E24C65DC-7377-472b-9ABA-BC803B73C61A which is a Web Site project to the existing check that the current item is a Project.